### PR TITLE
Getting a znodes children should not have a trailing slash

### DIFF
--- a/common/store/zookeeper/db.go
+++ b/common/store/zookeeper/db.go
@@ -141,7 +141,6 @@ func (db *zkDB) DeleteSection(Key string) error {
 
 //ListSection will list a directory
 func (db *zkDB) ListSection(Key string, Recursive bool) ([]string, error) {
-
-	result, _, err := db.Con.Children(Key)
+	result, _, err := db.Con.Children(Key.TrimRight("/"))
 	return result, err
 }

--- a/common/store/zookeeper/db.go
+++ b/common/store/zookeeper/db.go
@@ -141,6 +141,7 @@ func (db *zkDB) DeleteSection(Key string) error {
 
 //ListSection will list a directory
 func (db *zkDB) ListSection(Key string, Recursive bool) ([]string, error) {
-	result, _, err := db.Con.Children(Key.TrimRight("/"))
+	Key = strings.TrimSuffix(Key, "/")
+	result, _, err := db.Con.Children(Key)
 	return result, err
 }


### PR DESCRIPTION
Without this Zookeeper will return Node not found.
With this Zookeeper works correctly.
ListSections is not used much so it is easy to miss.

This seemed the easiest way to keep the interface consistent with etcd